### PR TITLE
stepson now appears after plant

### DIFF
--- a/Common/Systems/GoozmaSystem.cs
+++ b/Common/Systems/GoozmaSystem.cs
@@ -100,7 +100,7 @@ namespace CalamityHunt.Common.Systems
             bool conditionsMet = false;
             int slimeBoss = -1;
             bool king = true;
-            if (Main.slimeRain && Main.hardMode)
+            if (Main.slimeRain && (Main.hardMode || NPC.downedPlantBoss))
             {
                 foreach (NPC nPC in Main.npc.Where(n => (n.type == NPCID.KingSlime || n.type == NPCID.QueenSlimeBoss) && n.boss && n.active))
                 {


### PR DESCRIPTION
Makes the Wall of Flesh optional by having Goozma spawnable if you have beaten Plantera.
Plantera is one of the few bosses you can slay without defeating the Wall of Flesh, using an (intentional) Shimmer exploit with Photosynthesis Potions, and crafting the Portabulb.
(for waffles%)